### PR TITLE
INF-3910: Enabling mandatory Tagging

### DIFF
--- a/modules/kms_key/main.tf
+++ b/modules/kms_key/main.tf
@@ -1,5 +1,6 @@
 resource "aws_kms_key" "key" {
   policy = "${data.aws_iam_policy_document.policy.json}"
+  tags   = "${var.tags}"
 }
 
 resource "aws_kms_alias" "alias" {

--- a/modules/kms_key/variables.tf
+++ b/modules/kms_key/variables.tf
@@ -8,3 +8,9 @@ variable "additional_account_ids" {
   description = "List of additional account ids with permissions to use the key"
   default     = []
 }
+
+variable "tags" {
+  type        = "map"
+  description = "INF-3910: Mandatory tagging"
+  default     = {}
+}


### PR DESCRIPTION
```hcl
  ~ module.infra_encryption_key_cairo.aws_kms_key.key
      tags.%:               "0" => "7"
      tags.ComplianceScope: "" => "none"
      tags.Customer:        "" => "cairo"
      tags.Department:      "" => "engineering"
      tags.Environment:     "" => "prod"
      tags.Owner:           "" => "team-sre"
      tags.Purpose:         "" => "kms"
      tags.TagVersion:      "" => "1.0"
```